### PR TITLE
evas: Fixed typo in evas manager

### DIFF
--- a/evas/manager.py
+++ b/evas/manager.py
@@ -123,7 +123,7 @@ class EvasManager:
             }
         }
 
-        if 'model_params' in self.app_cfg:
+        if 'model_parameters' in self.app_cfg:
             model_params.update(self.app_cfg['model_parameters'])
         pipeline = self.app_cfg['pipeline']
         pipeline_version = self.app_cfg['pipeline_version']


### PR DESCRIPTION
Changes:
1. Fixed a typo of model_parameters
   in evas manager

Signed-off-by: Vishwas R <vishwas.r@intel.com>